### PR TITLE
[G2M] Use printenv instead of GH secrets

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -22,6 +22,12 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: Set Python version
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.7'
+          architecture: 'x64'
+
       - name: Cache Node Modules
         uses: actions/cache@v1
         with:
@@ -32,29 +38,20 @@ jobs:
             ${{ runner.OS }}-build-
             ${{ runner.OS }}-
 
+      - run: python -m pip install print-env --pre
       - run: npm install -g serverless @eqworks/notify
       - run: yarn install
-      - run: sls deploy --stage dev
+      - run: echo "PORTUNUS_TOKEN=$PORTUNUS_TOKEN" > .env && yarn deploy --stage dev
         env:
           # aws creds for deployment
           AWS_ACCESS_KEY_ID: ${{secrets.aws_access_key_id}}
           AWS_SECRET_ACCESS_KEY: ${{secrets.aws_secret_access_key}}
           # legion required environment variables
-          SLACK_BOT_TOKEN: ${{secrets.SLACK_BOT_TOKEN}}
-          SLACK_SIGNING_SECRET: ${{secrets.SLACK_SIGNING_SECRET}}
-          GITHUB_TOKEN: ${{secrets.GH_TOKEN}}
-          NETLIFY_TOKEN: ${{secrets.NETLIFY_TOKEN}}
-          YELP_API_KEY: ${{secrets.YELP_API_KEY}}
-          SLACK_OAUTH: ${{secrets.SLACK_OAUTH}}
+          PORTUNUS_TOKEN: ${{secrets.CD_PORTUNUS_TOKEN_JWT}}/19/dev
 
-      - name: Notify on deployment success
-        if: success()
-        run: notify deployment $GITHUB_REPOSITORY --commit=$GITHUB_SHA --stage=dev
+      - name: Notify on deployment status
+        if: ${{ always() }}
+        run: notify deployment $GITHUB_REPOSITORY --commit=$GITHUB_SHA --stage=dev --status=$JOB_STATUS
         env:
-          SLACK_HOOK: ${{secrets.SLACK_HOOK}}
-
-      - name: Notify on deployment failure
-        if: failure()
-        run: notify deployment $GITHUB_REPOSITORY --commit=$GITHUB_SHA --stage=dev --success=false
-        env:
-          SLACK_HOOK: ${{secrets.SLACK_HOOK}}
+          SLACK_HOOK: ${{ secrets.CD_SLACK_HOOK }}
+          JOB_STATUS: ${{ job.status }}

--- a/modules/bday.js
+++ b/modules/bday.js
@@ -65,29 +65,29 @@ const worker = async ({ command, channel_id, channel_name, response_url, user_id
           `Click :point_right: <${MIRO_URL}|here> :point_left: to sign! Instructions are found inside the card.`
         ].join('\n'),
         blocks: [
-            {
-              'type': 'header',
-              'text': {
-                'type': 'plain_text',
-                'text': `:tada: Birthday Alert for ${bdayPersonFullName} :tada:`,
-                'emoji': true
-              }
-            },
-            {
-              'type': 'section',
-              'text': {
-                'type': 'mrkdwn',
-                'text':  `*${bdayPersonFullName}*'s birthday is coming up soon! Take some time and leave a nice message for ${bdayPersonFullName} to read. Thanks! :smile:`
-              }
-            },
-            {
-              'type': 'section',
-              'text': {
-                'type': 'mrkdwn',
-                'text': `Click :point_right: <${MIRO_URL}|here> :point_left: to sign! Instructions are found inside the card.`
-              }
+          {
+            'type': 'header',
+            'text': {
+              'type': 'plain_text',
+              'text': `:tada: Birthday Alert for ${bdayPersonFullName} :tada:`,
+              'emoji': true
             }
-          ]
+          },
+          {
+            'type': 'section',
+            'text': {
+              'type': 'mrkdwn',
+              'text':  `*${bdayPersonFullName}*'s birthday is coming up soon! Take some time and leave a nice message for ${bdayPersonFullName} to read. Thanks! :smile:`
+            }
+          },
+          {
+            'type': 'section',
+            'text': {
+              'type': 'mrkdwn',
+              'text': `Click :point_right: <${MIRO_URL}|here> :point_left: to sign! Instructions are found inside the card.`
+            }
+          }
+        ]
       }))
     )
       .then(() => {
@@ -290,9 +290,9 @@ const worker = async ({ command, channel_id, channel_name, response_url, user_id
           }
         },
         {
-          "type": "image",
-          "image_url": "https://media.giphy.com/media/IQF90tVlBIByw/giphy.gif",
-          "alt_text": "minion birthday"
+          'type': 'image',
+          'image_url': 'https://media.giphy.com/media/IQF90tVlBIByw/giphy.gif',
+          'alt_text': 'minion birthday'
         }
       ]
     })


### PR DESCRIPTION
- for loading env vars to slack-worker, use print-env instead of GH secrets to ensure one place has updated env vars 
- also fixed lint errors