### PR TITLE
[G2M] Add date to modal when sending bday card for signing

### DIFF
--- a/modules/bday-blocks.js
+++ b/modules/bday-blocks.js
@@ -56,6 +56,23 @@ module.exports.customMessage = (ref) => ({
   }
 })
 
+module.exports.dates = (ref) => ({
+  'type': 'input',
+  'block_id': `date_${ref}`,
+  'label': {
+    'type': 'plain_text',
+    'text': 'Date'
+  },
+  'element': {
+    'type': 'plain_text_input',
+    'action_id': 'input',
+    'placeholder': {
+      'type': 'plain_text',
+      'text': 'add the birthday here'
+    }
+  }
+})
+
 module.exports.button = {
   'type': 'actions',
   'elements': [
@@ -89,8 +106,9 @@ module.exports.removeButton = {
   // 'block_id': 'remove',
 }
 
-module.exports.signMessage = ([{ fullName, url }, ...rest], sender) => {
-  let name = fullName
+module.exports.signMessage = ([{ fullName, url, date }, ...rest], sender) => {
+  let names = fullName
+  let namesWithDates = `${fullName}'s (${date})`
 
   let getClick = (name, url, type = 'text') => {
     const message = `Click :point_right: <${url}|here> :point_left: to sign a card for ${name}!`
@@ -110,8 +128,9 @@ module.exports.signMessage = ([{ fullName, url }, ...rest], sender) => {
   let allCards = `${url}`
 
   if (rest.length) {
-    for (let { fullName, url } of rest) {
-      name += ` & ${fullName}`
+    for (let { fullName, url, date } of rest) {
+      names += ` & ${fullName}`
+      namesWithDates += ` & ${fullName}'s (${date})`
       clickSectionText.push(getClick(fullName, url))
       clickSectionBlock.push(getClick(fullName, url, 'block'))
       allCards += `, ${url}`
@@ -119,8 +138,8 @@ module.exports.signMessage = ([{ fullName, url }, ...rest], sender) => {
   }
 
   const text = [
-    `:tada: Birthday Alert for ${name} :tada:`,
-    `*${name}'s* birthday is coming up soon! Take some time and leave a nice message for them to read. Thanks! :smile:`,
+    `:tada: Birthday Alert for ${names} :tada:`,
+    `*${namesWithDates}* birthday is coming up soon! Take some time and leave a nice message for ${names} to read. Thanks! :smile:`,
     ...clickSectionText,
     'Instructions are found inside the card.',
   ].join('\n')
@@ -130,7 +149,7 @@ module.exports.signMessage = ([{ fullName, url }, ...rest], sender) => {
       'type': 'header',
       'text': {
         'type': 'plain_text',
-        'text': `:tada: Birthday Alert for ${name} :tada:`,
+        'text': `:tada: Birthday Alert for ${names} :tada:`,
         'emoji': true
       }
     },
@@ -138,7 +157,7 @@ module.exports.signMessage = ([{ fullName, url }, ...rest], sender) => {
       'type': 'section',
       'text': {
         'type': 'mrkdwn',
-        'text': `*${name}*'s birthday is coming up soon! Take some time and leave a nice message for them to read. Instructions are found inside the card. Thanks! :smile:`
+        'text': `*${namesWithDates}* birthday is coming up soon! Take some time and leave a nice message for ${names} to read. Instructions are found inside the card. Thanks! :smile:`
       }
     },
     ...clickSectionBlock,
@@ -153,12 +172,13 @@ module.exports.signMessage = ([{ fullName, url }, ...rest], sender) => {
     }
   ]
 
+  const isMultipleCards = (rest.length) ? 'cards have' : 'card has'
   const confirmation = [
     {
       'type': 'header',
       'text': {
         'type': 'plain_text',
-        'text': `The card has been sent to everyone except ${name} to be signed! :tada:`,
+        'text': `The ${isMultipleCards} been sent to everyone except ${names} to be signed! :tada:`,
         'emoji': true
       }
     },

--- a/modules/bday-interactive.js
+++ b/modules/bday-interactive.js
@@ -27,6 +27,9 @@ module.exports.bdayInteractive = ({ type, values }) => {
           validData(key, input.value)
           acc[user_index] = { ...acc[user_index], url: input.value }
         }
+        if (key.includes('date')) {
+          acc[user_index] = { ...acc[user_index], date: input.value }
+        }
         if (key.includes('message')) {
           acc[user_index] = { ...acc[user_index], message: input.value }
         }

--- a/modules/bday.js
+++ b/modules/bday.js
@@ -7,6 +7,7 @@ const {
   removeButton,
   signMessage,
   customMessage,
+  dates,
   sendText,
   sendBlocks,
   sendConfirmation,
@@ -89,7 +90,7 @@ const worker = async ({
             'type': 'plain_text',
             'text': 'Bday details'
           },
-          'blocks': [..._blocks(state.ref), button],
+          'blocks': [..._blocks(state.ref), dates(state.ref), button],
           'close': {
             'type': 'plain_text',
             'text': 'Nevermind'
@@ -108,13 +109,13 @@ const worker = async ({
       const _buttons = blocks.pop()
 
       if (action.action_id === 'add') {
-        if (blocks.length === 3) {
+        if (blocks.length === 4) {
           _buttons.elements.push(removeButton)
         }
-        updatedBlocks = [...blocks, ..._blocks(ref + 1), _buttons]
+        updatedBlocks = [...blocks, ..._blocks(ref + 1), dates(ref + 1), _buttons]
       } else {
-        blocks.splice(-3)
-        if (blocks.length === 3) {
+        blocks.splice(-4)
+        if (blocks.length === 4) {
           updatedBlocks = [...blocks, button]
         } else {
           updatedBlocks = [...blocks, _buttons]
@@ -157,6 +158,7 @@ const worker = async ({
       }
 
       const bdayData = Object.values(data)
+
       const { text, blocks, confirmation } = signMessage(bdayData, sender)
 
       // return web.conversations.open({ users: members.toString() })


### PR DESCRIPTION
- Date block (text input) added in modal when `/bday sign` is used so the message sent to every EQ member will know when the bdays are and decide when to sign the card
![Screen Shot 2020-11-18 at 2 34 01 PM](https://user-images.githubusercontent.com/42495034/99579461-37126c00-29ac-11eb-9212-9b83b4727631.png)

- Message other EQ members will get:
![Screen Shot 2020-11-18 at 2 32 42 PM](https://user-images.githubusercontent.com/42495034/99579512-47c2e200-29ac-11eb-9f53-f1d05b2545cb.png)

- also fixed grammar in the message sent back to prompter when multiple cards are sent
![Screen Shot 2020-11-18 at 2 33 01 PM](https://user-images.githubusercontent.com/42495034/99579550-514c4a00-29ac-11eb-9303-01c499445b0f.png)

