### PR TITLE
[G2M] Release - show prompt in channel when release command completed

### DIFF
--- a/modules/release.js
+++ b/modules/release.js
@@ -53,7 +53,7 @@ const formatRepoStage = ({ repo, stage }) => isVersioned(repo) ? repo : `${repo}
 
 const worker = async ({ repo, stage = 'dev', response_url }) => {
   const r = {
-    response_type: 'ephemeral',
+    response_type: 'in_channel',
     text: `${formatRepoStage({ repo, stage })} cannot be released`,
   }
   const tag_name = await getNextVersion({ repo, stage })

--- a/modules/release.js
+++ b/modules/release.js
@@ -49,7 +49,7 @@ const getNextVersion = async ({ repo, stage = 'dev' }) => {
 
 const isPre = ({ repo, stage = 'dev' }) => !isVersioned(repo) && stage.toLowerCase() === 'dev'
 
-const formatRepoStage = ({ repo, stage }) => isVersioned(repo) ? repo : `${repo} (${stage || 'unknown stage'})}`
+const formatRepoStage = ({ repo, stage }) => isVersioned(repo) ? repo : `${repo} (${stage || 'unknown stage'})`
 
 const worker = async ({ repo, stage = 'dev', response_url }) => {
   const r = {


### PR DESCRIPTION
- show in channel who is initiating release + when release is successful
- ephemeral if release does not go through
<img width="582" alt="Screen Shot 2020-12-18 at 4 20 23 PM" src="https://user-images.githubusercontent.com/42495034/102662497-f9406900-414c-11eb-98a4-9b5cb618e16b.png">

-also removed random curly bracket in the response message shown below:
<img width="340" alt="Screen Shot 2020-12-18 at 1 18 13 PM" src="https://user-images.githubusercontent.com/42495034/102647296-824aa680-4133-11eb-88ee-3e0bd7799ce0.png">


