### PR TITLE
[G2M] Release/correctly interpret dev stage

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@ const express = require('express')
 const serverless = require('serverless-http')
 const axios = require('axios')
 
-const { lambda, getFuncName } = require('./modules/util')
+const { lambda, getFuncName } = require('./modules/lib/util')
 const { routes } = require('./modules')
 const { verifySlack } = require('./modules/lib/middleware')
 const { bdayInteractive } = require('./modules/lib/bday-interactive')


### PR DESCRIPTION
[context](https://eqworks.slack.com/archives/CB7557258/p1640108783003800)

![image](https://user-images.githubusercontent.com/53827672/146984483-64f5378d-94b4-4e85-a518-37d15c531a86.png)

Handling the case where the `/release` command is being used for `dev` stage on a repo that does not use semver.

---

Also, in order to get the app to run locally, I had to correct the following import:

https://github.com/EQWorks/legion/blob/fcabe25d45b523cd57133b6ae31a3a7226183772/app.js#L5

Not sure if the file structure is somehow different in production - if so we can drop 846068721ea111e4192f0f4ee5ab92c239adda78