### PR TITLE
[G2M] worker - correctly access module routes

### DIFF
--- a/slack-worker.js
+++ b/slack-worker.js
@@ -1,8 +1,8 @@
-const modules = require('./modules')
+const { routes } = require('./modules')
 
 // `type` is the name of the export key in ./modules/index
 module.exports.handler = async ({ type, payload }) => {
-  const { worker } = modules[type]
+  const { worker } = routes[type]
   await worker(payload)
   return { statusCode: 200 }
 }


### PR DESCRIPTION
[ref](https://eqworks.slack.com/archives/G1FFQ77MF/p1640234686134900)

Slack commands `/diff` and `/release` would hang and/or fail prior to this change. Not sure why it didn't show up before... 