### PR TITLE
[G2M] Events stub, and revision on diff product lock, fix deployment env var sourcing

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.8'
           architecture: 'x64'
 
       - uses: actions/cache@v2
@@ -32,16 +32,16 @@ jobs:
             ${{ runner.OS }}-build-
             ${{ runner.OS }}-
 
-      - run: python -m pip install print-env --pre
+      - run: python -m pip install print-env
       - run: npm install -g serverless @eqworks/notify
       - run: yarn install
-      - run: echo "PORTUNUS_TOKEN=$PORTUNUS_TOKEN" > .env && yarn deploy --stage dev
+      - run: env $(print-env) sls deploy --stage=dev
         env:
           # aws creds for deployment
           AWS_ACCESS_KEY_ID: ${{secrets.aws_access_key_id}}
           AWS_SECRET_ACCESS_KEY: ${{secrets.aws_secret_access_key}}
           # legion required environment variables
-          PORTUNUS_TOKEN: ${{secrets.CD_PORTUNUS_TOKEN_JWT}}/19/dev
+          PORTUNUS_TOKEN: ${{secrets.CD_PORTUNUS_TOKEN_JWT}}/legion/dev
 
       - name: Generate tag associated release notes
         if: ${{ success() }}

--- a/app.js
+++ b/app.js
@@ -24,6 +24,12 @@ app.get('/', (_, res, next) => {
   axios.get('https://api.github.com/zen').then(({ data }) => res.send(data)).catch(next)
 })
 
+// TODO: stub for Slack App Manifest settings.event_subscriptions.request_url
+app.all('/events', (req, res) => {
+  const { body: { challenge } = {} } = req
+  return res.status(200).json({ challenge })
+})
+
 if (process.env.DEPLOYED) {
   app.use(verifySlack)
 }
@@ -185,12 +191,6 @@ app.all('/interactive', (req, res) => {
       return res.sendStatus(200)
     }
   }
-})
-
-// TODO: stub for Slack App Manifest settings.event_subscriptions.request_url
-app.all('/events', (req, res) => {
-  const { body: { challenge } = {} } = req
-  return res.status(200).json({ challenge })
 })
 
 // catch-all error handler

--- a/app.js
+++ b/app.js
@@ -30,7 +30,7 @@ if (process.env.DEPLOYED) {
 
 // secondary prefix for backward compat
 Object.entries(routes).forEach(([uri, { route }]) => {
-  app.use(`/${uri}`, route)
+  app.all(`/${uri}`, route)
 })
 
 /*
@@ -81,7 +81,7 @@ e.g.
   ]
 }
 */
-app.use('/interactive', (req, res) => {
+app.all('/interactive', (req, res) => {
   const parsed = JSON.parse(req.body.payload)
 
   const {
@@ -188,7 +188,7 @@ app.use('/interactive', (req, res) => {
 })
 
 // TODO: stub for Slack App Manifest settings.event_subscriptions.request_url
-app.use('/events', (req, res) => {
+app.all('/events', (req, res) => {
   const { body: { challenge } = {} } = req
   return res.status(200).json({ challenge })
 })

--- a/app.js
+++ b/app.js
@@ -187,6 +187,12 @@ app.use('/interactive', (req, res) => {
   }
 })
 
+// TODO: stub for Slack App Manifest settings.event_subscriptions.request_url
+app.use('/events', (req, res) => {
+  const { body: { challenge } = {} } = req
+  return res.status(200).json({ challenge })
+})
+
 // catch-all error handler
 // eslint disable otherwise not able to catch errors
 // eslint-disable-next-line no-unused-vars

--- a/modules/lib/middleware.js
+++ b/modules/lib/middleware.js
@@ -11,6 +11,10 @@ const _verify = ({
   const hmac = crypto.createHmac('sha256', SLACK_SIGNING_SECRET)
   const [version, hash] = (signature || '').split('=')
 
+  if (!version || !hash) {
+    return false
+  }
+
   // Check if the timestamp is too old
   const fiveMinutesAgo = parseInt(Date.now() / 1000) - (60 * 5)
   if (timestamp < fiveMinutesAgo) {

--- a/modules/lib/middleware.js
+++ b/modules/lib/middleware.js
@@ -9,7 +9,7 @@ const _verify = ({
   rawBody,
 }) => {
   const hmac = crypto.createHmac('sha256', SLACK_SIGNING_SECRET)
-  const [version, hash] = signature.split('=')
+  const [version, hash] = (signature || '').split('=')
 
   // Check if the timestamp is too old
   const fiveMinutesAgo = parseInt(Date.now() / 1000) - (60 * 5)

--- a/modules/lib/products.js
+++ b/modules/lib/products.js
@@ -47,15 +47,20 @@ module.exports.getKey = ({ channel, product, timestamp = new Date(), tsFloor = 1
   return key
 }
 
-module.exports.getSetLock = (dbName) => async ({ user_id, channel, product, key: _key, hard = true }) => {
+module.exports.getSetLock = (dbName) => async ({
+  user_id,
+  channel,
+  product,
+  timestamp = new Date(),
+  key = this.getKey({ channel, product, timestamp }),
+  hard = true,
+}) => {
   if (!process.env.DETA_KEY) {
     return true
   }
   const deta = Deta(process.env.DETA_KEY)
   const db = deta.Base(dbName)
-  const timestamp = new Date()
   const payload = { timestamp, user_id, channel, product }
-  const key = _key || this.getKey({ channel, product, timestamp })
   if (hard) { // use deta.Base.insert to force error if already exists
     return await db.insert(payload, key).catch(() => ({ ...payload, key, hard, locked: true }))
   }
@@ -72,5 +77,5 @@ module.exports.releaseLock = (dbName) => (key) => {
   }
   const deta = Deta(process.env.DETA_KEY)
   const db = deta.Base(dbName)
-  return db.delete(key) // returns null regardless
+  return db.delete(key) // return null regardless, currently buggy
 }


### PR DESCRIPTION
a few breaking changes introduced from multiple forces:
- Slack introduced App Manifest, which replaces the previous UI-only app configurations for things like slash command. With it, our `events` setting is broken without a `request_url` for it, thus the newly introduced `/events` stub endpoint (that does a blank challenge verification per Slack doc)
- Portunus API introduced a new major release. While still maintained backward compatibility with the JWT itself (the new JWT would be generated with a team, while the legacy one is team-less), it would no longer support the digit-based project naming that was deprecated from last year's major breaking change (such as `19` instead of `legion`). The silver lining is that the companion `print-env` 2.2 is finally here and it supports proper self-bootstrapping through available `$PORTUNUS_TOKEN` without working around the previous quirk by needing to write it to a temp `.env` file and source it that way
- some effort to revise the product lock mechanism, but still confirm that the release (delete key) mechanism is buggy when running locally

to minimize boilerplate maintenance, and potentially to work around the interactive modal quirks, we're going to potentially consider https://slack.dev/bolt-js (so we don't have to worry about slack verification implementation, etc.)