### PR TITLE
[G2M] devops - add provisionedConcurrency clause to serverless.yml

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -41,6 +41,8 @@ plugins:
 functions:
   receiver:
     handler: app.handler
+    # keep this hot for immediate slack response
+    provisionedConcurrency: 1
     events:
       - http:
           path: slack/events


### PR DESCRIPTION
[ref](https://eqworks.slack.com/archives/CB7557258/p1642201132000400)

should eliminate potential timeout error after some time of inactivity