### PR TITLE
[G2M] diff - bring back getChannelName for privategroup channel name

### DIFF
--- a/modules/lib/util.js
+++ b/modules/lib/util.js
@@ -46,3 +46,12 @@ module.exports.errMsg = (err) => `\`\`\`${err.toString()}\`\`\``
 module.exports.getSpecificGroupIds = (groups) => Object.entries(SLACK_GROUP_IDS)
   .filter(i => groups.includes(i[0]))
   .map(i => i[1])
+
+module.exports.getChannelName = async ({ channel_name, channel_id }) => {
+  let cn = channel_name
+  if (channel_name === 'privategroup') {
+    const { channel: { name } = {} } = await web.conversations.info({ channel: channel_id })
+    cn = name
+  }
+  return cn
+}


### PR DESCRIPTION
forgot that `channel_name` from the payload would only include public channels, where private channels would all be named as "privategroup" and requires additional API call to obtain the actual channel name

also commented out the currently not working `gCalendarGetEvents` (invalid API token perhaps). would need a better solution (maybe as a google workplace app with app-level token etc)