### PR TITLE
[G2M] diff - expand to support generic github repos with tag-releases

### DIFF
--- a/modules/lib/util.js
+++ b/modules/lib/util.js
@@ -50,9 +50,11 @@ module.exports.getSpecificGroupIds = (groups) => Object.entries(SLACK_GROUP_IDS)
 
 module.exports.getChannelName = async ({ channel_name, channel_id }) => {
   let cn = channel_name
+  let ci = channel_id
   if (channel_name === 'privategroup') {
-    const { channel: { name } = {} } = await web.conversations.info({ channel: channel_id })
+    const { channel: { name, id } = {} } = await web.conversations.info({ channel: channel_id })
     cn = name
+    ci = id
   }
-  return cn
+  return { name: cn, id: ci }
 }

--- a/modules/lib/util.js
+++ b/modules/lib/util.js
@@ -12,6 +12,7 @@ const SLACK_GROUP_IDS = {
   'overlordteam': 'S1FG0BA3C',
   'overseerteam': 'S7KPS7K7S',
   'flashteam': 'S1FFKS7FS',
+  'product-group': 'S1FFRAXQA',
 }
 
 module.exports.lambda = new AWS.Lambda({


### PR DESCRIPTION
* generic github repo support (ones with tag/releases)
  * scoped to only allow slack `@product-group` users to be able to use (also acts as fallback for any `SERVICES` and `CLIENTS` without specified access `groups`)

![locussdk](https://user-images.githubusercontent.com/2837532/150866304-4b7f6125-7281-4610-9e15-bf1c5ba68a36.png)
![enrichdata](https://user-images.githubusercontent.com/2837532/150866340-2cc7bc07-bf35-4808-b756-cb3c19aba11f.png)

* improved lock message to create proper links to slack entities (channel and user)

before:
![before](https://user-images.githubusercontent.com/2837532/150866596-2be15607-00c2-42f1-8ff3-ae9a7c863d23.png)

after:
![after](https://user-images.githubusercontent.com/2837532/150866557-d165a3e2-ba20-47b3-9bba-982f7f131b80.png)

* small change to support env var configured `GITHUB_ORG` and `GITHUB_USER` (wip to parameterize more in the near future)