### PR TITLE
[G2M] devops - add missing env vars, and scan-env in main CI workflow

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -11,7 +11,9 @@ jobs:
   deploy-dev:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,3 +39,9 @@ jobs:
           node-version: 14.x
 
       - run: npx @eqworks/commit-watch -b ${{ github.event.pull_request.base.sha }} -h ${{ github.event.pull_request.head.sha }} -v
+
+  scan-env:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: npx @eqworks/scan-env --strict

--- a/modules/lib/products.js
+++ b/modules/lib/products.js
@@ -34,7 +34,7 @@ module.exports.SERVICES = {
 module.exports.CLIENTS = {
   overlord: {
     siteId: 'overlord.eqworks.io', // netlify site ID, also the main domain
-    projectId: 'prj_TqFdYCSg60gcDJnnfeJ68bb7wPiy', // vercel project ID
+    projectId: 'prj_qgapSHRWtoi5pUdGrHFXns2qFljX', // vercel project ID
     stages: ['master', 'prod'],
     groups: getSpecificGroupIds(['flashteam', 'overseerteam', 'overlordteam'])
   },

--- a/modules/lib/util.js
+++ b/modules/lib/util.js
@@ -22,7 +22,7 @@ module.exports.lambda = new AWS.Lambda({ apiVersion: '2015-03-31', region: AWS_R
 module.exports.legionLambda = new AWS.Lambda({
   apiVersion: '2015-03-31',
   region: AWS_REGION,
-  endpoint: process.env.IS_OFFLINE // available through serverless-offline plugin
+  endpoint: (process.env.IS_OFFLINE || false) // available through serverless-offline plugin
     ? 'http://localhost:3002'
     : `https://lambda.${AWS_REGION}.amazonaws.com`,
 })

--- a/serverless.yml
+++ b/serverless.yml
@@ -33,6 +33,9 @@ provider:
     GOOGLE_SECRET_KEY: ${env:GOOGLE_SECRET_KEY}
     GOOGLE_REFRESH_TOKEN: ${env:GOOGLE_REFRESH_TOKEN}
     GOOGLE_DEMO_CALENDAR: ${env:GOOGLE_DEMO_CALENDAR}
+    VERCEL_TEAM: ${env:VERCEL_TEAM}
+    VERCEL_TOKEN: ${env:VERCEL_TOKEN}
+    DETA_KEY: ${env:DETA_KEY}
 
 plugins:
   - serverless-offline


### PR DESCRIPTION
follow up of #104 and hardened CI workflow to preemptively check for potentially missing env vars